### PR TITLE
Update NearestPlayer.java

### DIFF
--- a/src/main/java/com/jaoafa/MyMaid2/Lib/NearestPlayer.java
+++ b/src/main/java/com/jaoafa/MyMaid2/Lib/NearestPlayer.java
@@ -5,9 +5,9 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 public class NearestPlayer {
-	Boolean status;
-	Player player = null;
-	double closest = -1;
+	private boolean status;
+	private Player player = null;
+	private double closest = -1;
 	public NearestPlayer(Location loc){
 		double closest = Double.MAX_VALUE;
 		Player closestp = null;


### PR DESCRIPTION
プロパティがボクシング型になっていたので修正、プロパティの隠蔽(ゲッターがpublicになっていることによる)